### PR TITLE
Move Subheader outside of .main-content

### DIFF
--- a/templates/layouts/django/base.html
+++ b/templates/layouts/django/base.html
@@ -26,12 +26,14 @@
       </div>
     </div>
 
+    <div class="global-subheader">
+      <div class="container">
+        {% block global_subheader %}{% endblock %}
+      </div>
+    </div>
+
     <div class="main-content" role="main">
       <div class="container">
-        <div class="global-subheader">
-          {% block global_subheader %}{% endblock %}
-        </div>
-
         {% block content %}{% endblock %}
       </div>
     </div>

--- a/templates/layouts/django/base.html
+++ b/templates/layouts/django/base.html
@@ -32,11 +32,11 @@
       </div>
     </div>
 
-    <div class="main-content" role="main">
+    <main class="main-content" role="main">
       <div class="container">
         {% block content %}{% endblock %}
       </div>
-    </div>
+    </main>
 
     <div class="global-footer">
       <div class="container">

--- a/templates/layouts/erb/base.erb
+++ b/templates/layouts/erb/base.erb
@@ -31,18 +31,20 @@
       </div>
     </div>
 
+    <% if content_for? :global_subheader %>
+      <div class="global-subheader">
+        <div class="container">
+          <% if defined? yield_content %>
+            <%= yield_content :global_subheader %>
+          <% else %>
+            <%= yield :global_subheader %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
     <div class="main-content" role="main">
       <div class="container">
-        <% if content_for? :global_subheader %>
-          <div class="global-subheader">
-            <% if defined? yield_content %>
-              <%= yield_content :global_subheader %>
-            <% else %>
-              <%= yield :global_subheader %>
-            <% end %>
-          </div>
-        <% end %>
-
         <%= yield %>
       </div>
     </div>

--- a/templates/layouts/erb/base.erb
+++ b/templates/layouts/erb/base.erb
@@ -43,11 +43,11 @@
       </div>
     <% end %>
 
-    <div class="main-content" role="main">
+    <main class="main-content" role="main">
       <div class="container">
         <%= yield %>
       </div>
-    </div>
+    </main>
 
     <div class="global-footer">
       <div class="container">

--- a/templates/layouts/jinja/base.html
+++ b/templates/layouts/jinja/base.html
@@ -25,12 +25,14 @@
       </div>
     </div>
 
+    <div class="global-subheader">
+      <div class="container">
+        {% block global_subheader %}{% endblock %}
+      </div>
+    </div>
+
     <div class="main-content" role="main">
       <div class="container">
-        <div class="global-subheader">
-          {% block global_subheader %}{% endblock %}
-        </div>
-
         {% block content %}{% endblock %}
       </div>
     </div>

--- a/templates/layouts/jinja/base.html
+++ b/templates/layouts/jinja/base.html
@@ -31,11 +31,11 @@
       </div>
     </div>
 
-    <div class="main-content" role="main">
+    <main class="main-content" role="main">
       <div class="container">
         {% block content %}{% endblock %}
       </div>
-    </div>
+    </main>
 
     <div class="global-footer">
       <div class="container">


### PR DESCRIPTION
This moves the .global-subheadar element to be outside of the .main-content element.

Giving the subheader it's own place in the basic hierarchy allows the main content element to be targeted without affecting children of the subheader.

This PR also changes the .main-content element from a `div` to `main`.
